### PR TITLE
[Welcomer] Fix botrole

### DIFF
--- a/welcomer/welcomer.py
+++ b/welcomer/welcomer.py
@@ -230,7 +230,7 @@ Message Examples:
             if db[server.id]['botroletoggle'] is True:
                 roleobj = discord.utils.get(server.roles, id=db[server.id]['botrole'])
                 if roleobj is not None:
-                    await self.bot.add_roles(member, roleobj[0])
+                    await self.bot.add_roles(member, roleobj)
         await asyncio.sleep(1)
         if db[server.id]['join'] is False:
             return

--- a/welcomer/welcomer.py
+++ b/welcomer/welcomer.py
@@ -230,6 +230,7 @@ Message Examples:
             if db[server.id]['botroletoggle'] is True:
                 roleobj = discord.utils.get(server.roles, id=db[server.id]['botrole'])
                 if roleobj is not None:
+                    await asyncio.sleep(3)
                     await self.bot.add_roles(member, roleobj)
         await asyncio.sleep(1)
         if db[server.id]['join'] is False:


### PR DESCRIPTION
```py
Ignoring exception in member_join
Traceback (most recent call last):
  File "lib/discord/ext/commands/bot.py", line 252, in _run_extra
    yield from coro(*args, **kwargs)
  File "/Red-DiscordBot/cogs/welcomer.py", line 233, in on_member_join
    await self.bot.add_roles(member, roleobj[0])
TypeError: 'Role' object does not support indexing
```